### PR TITLE
Add transform logging support, a better error, and a better death

### DIFF
--- a/lib/build.js
+++ b/lib/build.js
@@ -20,6 +20,9 @@ module.exports = function ( command, gobblefile ) {
 			task.build({
 				dest: dest,
 				force: command.force
+			}).catch( function ( err ) {
+				logger.error( err );
+				process.exit( 1 );
 			});
 
 			task.on( 'info',  logger.info );

--- a/lib/build.js
+++ b/lib/build.js
@@ -11,7 +11,13 @@ module.exports = function ( command, gobblefile ) {
 
 		try {
 			delete require.cache[ gobblefile ];
-			task = require( gobblefile ).build({
+			task = require( gobblefile );
+
+			if ( !task._gobble ) {
+				throw new Error( 'Did you forget to export something in your gobblefile?' );
+			}
+
+			task.build({
 				dest: dest,
 				force: command.force
 			});

--- a/lib/index.js
+++ b/lib/index.js
@@ -105,16 +105,19 @@ else {
 		// Execute command
 		if ( command._[0] === 'build' ) {
 			process.env.GOBBLE_ENV = command.env || 'production';
+			process.env.GOBBLE_COMMAND = 'build';
 			return build( command, env.configPath );
 		}
 
 		if ( command._[0] === 'watch' ) {
 			process.env.GOBBLE_ENV = command.env || 'development';
+			process.env.GOBBLE_COMMAND = 'watch';
 			return watch( command, env.configPath );
 		}
 
 		if ( !command._[0] || command._[0] === 'serve' ) {
 			process.env.GOBBLE_ENV = command.env || 'development';
+			process.env.GOBBLE_COMMAND = 'serve';
 			return serve( command, env.configPath );
 		}
 

--- a/lib/utils/logger.js
+++ b/lib/utils/logger.js
@@ -6,6 +6,7 @@ var util = require( 'util' ),
 	ansiRegex = require( 'ansi-regex' ),
 	sorcery = require( 'sorcery' ),
 	frames = require( './frames' ),
+	frameLength = plainText( frames[0] ).length,
 	summariseChanges = require( './summariseChanges' ),
 	tryInstallPlugin = require( './tryInstallPlugin' ),
 	getSyntaxErrorBlock = require( './getSyntaxErrorBlock' ),
@@ -59,6 +60,22 @@ function indent ( str, indentAmount ) {
 	lines.push( currentLine );
 
 	return lines.join( indentStr );
+}
+
+function clearLineAfter ( offset, text ) {
+	var cols;
+
+	if ( !process.stderr.isTTY ) {
+		return text;
+	}
+
+	cols = process.stderr.columns - ( offset + text.length );
+
+	if ( cols > 0 ) {
+		return text + new Array( cols ).join( ' ' );
+	} else {
+		return text.substring( 0, process.stderr.columns - offset - 1 );
+	}
 }
 
 function plainText ( str ) {
@@ -240,7 +257,7 @@ errorHandlers = {
 
 logger = {
 	info: function ( details ) {
-		var fn, message;
+		var fn, message, args;
 
 		if ( progressIndicator ) {
 			progressIndicator.stop();
@@ -249,11 +266,18 @@ logger = {
 
 		if ( fn = messages[ details.code ] ) {
 			message = fn( details );
+		} else if ( typeof details.message === 'string' ) {
+			args = [ details.message ];
+			if ( details.parameters ) {
+				args = args.concat( details.parameters );
+			}
+			message = util.format.apply( null, args );
 		} else {
 			message = util.format.apply( null, arguments );
 		}
 
 		if ( details.progressIndicator ) {
+			message = clearLineAfter( frameLength, message );
 			progressIndicator = stevedore({
 				message: message,
 				frames: frames

--- a/lib/watchOrServe.js
+++ b/lib/watchOrServe.js
@@ -44,6 +44,10 @@ module.exports = function ( gobblefile, getTask ) {
 		try {
 			node = require( gobblefile );
 
+			if ( !node._gobble ) {
+				throw new Error( 'Did you forget to export something in your gobblefile?' );
+			}
+
 			if ( task ) {
 				task.resume( node );
 			} else {


### PR DESCRIPTION
Hopefully this is a useful little blob of changes:

* It adds support for plain text logging so that transforms can update their status too.
* It keeps messages that change from long to short from having the long message hang around beyond the new short one. It also should keep messages that are wider than the terminal from making each progress frame draw spit out a new line.
* It prompts those of us who forget our `module.exports` in our gobblefile to add it instead of throwing an `undefined is not a function` error.
* It makes `gobble build` die with a non-zero code when the build fails. This should make gobble automated-build friendly.