### PR TITLE
Blank regular info messages to keep progress messages running beyond them

### DIFF
--- a/lib/utils/logger.js
+++ b/lib/utils/logger.js
@@ -22,12 +22,7 @@ var util = require( 'util' ),
 	GOBBLE_ERROR   = chalk.bgRed.white( 'gobble:' ) + ' ',
 	GOBBLE_WARNING = chalk.bgYellow.black( 'gobble:' ) + ' ';
 
-var lastInfoMessage;
-
 function info ( message ) {
-	if ( lastInfoMessage === message ) return;
-	lastInfoMessage = message;
-
 	write( GOBBLE_INFO + indent( message, 8 ) );
 }
 


### PR DESCRIPTION
I have a gobblefile that uses a few single source nodes for several separate transform paths before merging some and doing bizarro things with others. Each time a node finishes processing, it spams the output with the same completion message a few times. This squashes repeat info messages to avoid that.

It also adds blanking to regular info messages so that previous progress messages don't get partially dangled beyond the end of them.
