### PR TITLE
Node doesn't keep stderr size updated

### DIFF
--- a/lib/utils/logger.js
+++ b/lib/utils/logger.js
@@ -41,7 +41,7 @@ function indent ( str, indentAmount ) {
 		return str;
 	}
 
-	numColumns = process.stderr.columns - indentAmount;
+	numColumns = process.stdout.columns - indentAmount;
 	indentStr = new Array( indentAmount + 1 ).join( ' ' );
 
 	words = str.split( ' ' );
@@ -71,12 +71,12 @@ function clearLineAfter ( offset, text ) {
 		return text;
 	}
 
-	cols = process.stderr.columns - ( offset + text.length );
+	cols = process.stdout.columns - ( offset + text.length );
 
 	if ( cols > 0 ) {
 		return text + new Array( cols ).join( ' ' );
 	} else {
-		return text.substring( 0, process.stderr.columns - offset - 1 );
+		return text.substring( 0, process.stdout.columns - offset - 1 );
 	}
 }
 


### PR DESCRIPTION
...but it does keep stdout updated, so this switches to using `process.stdout.columns`. I suppose the only risk would be that someone redirects stdout but not stderr?