### PR TITLE
Command line help for watch command

### DIFF
--- a/lib/help.md
+++ b/lib/help.md
@@ -7,6 +7,7 @@
     gobble -v | --version
     gobble [serve] [-p|--port <port>] [-e|--env <env>]
     gobble build [-f|--force] [-e|--env <env>] <dest>
+    gobble watch [-f|--force] [-e|--env <env>] <dest>
 
   Options:
     -h --help      Show this message


### PR DESCRIPTION
Documentation for this command was previously only on gobble-cli's
repository and not the CLI or the main gobble repository.