### PR TITLE
Fix for exceptions thrown by logger

### DIFF
--- a/lib/utils/logger.js
+++ b/lib/utils/logger.js
@@ -330,7 +330,7 @@ logger = {
 		}
 
 		else {
-			error( ( err.message || err ).trim() );
+			error( ( err.message || err + '' ).trim() );
 
 			console.log( chalk.red( '>>>' ) );
 			console.log( chalk.grey( err.stack ) );


### PR DESCRIPTION
Intermittent EPERM errors caused by the unlink operation on Windows will make the logger throw an exception instead of logging the error.