### PR TITLE
→ 0.7.1, restart watching gobblefile if it's deleted/moved away

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # changelog
 
+## 0.7.1
+
+* Watch gobblefile again when deleted (happens in editors which rename old files as backups)
+
 ## 0.7.0
 
 * Switch to pathwatcher

--- a/lib/utils/logger.js
+++ b/lib/utils/logger.js
@@ -118,6 +118,10 @@ messages = {
 		return 'gobblefile changed. restarting server';
 	},
 
+	GOBBLEFILE_DELETED: function () {
+		return 'gobblefile deleted or moved away. trying to read again';
+	},
+
 	MERGE_START: function ( x ) {
 		return chalk.bold( x.id ) + ' running...';
 	},

--- a/lib/watchOrServe.js
+++ b/lib/watchOrServe.js
@@ -6,15 +6,26 @@ module.exports = function ( gobblefile, getTask ) {
 		resuming;
 
 	resume();
+logger.info({message: 'gobblefile is ' + gobblefile});
+	function watch () {
+		pathwatcher.watch( gobblefile, type => {
 
-	pathwatcher.watch( gobblefile, type => {
-		if ( type === 'change' ) restart();
-	});
+			if ( type === 'change' ) {
+				logger.info({ code: 'GOBBLEFILE_CHANGED' });
+				return restart();
+			}
+
+			if ( type === 'delete' ) {
+				logger.info({ code: 'GOBBLEFILE_DELETED' });
+				return setTimeout( watch, 2000 );
+			}
+		});
+	}
+
+	watch();
 
 	function restart () {
 		if ( resuming ) return;
-
-		logger.info({ code: 'GOBBLEFILE_CHANGED' });
 
 		process.env.GOBBLE_RESET_UID = 'reset';
 

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "gobble-cli",
   "description": "Command line interface for gobble",
-  "version": "0.7.0",
+  "version": "0.7.1",
   "author": "Rich Harris",
   "license": "MIT",
   "repository": "https://github.com/gobblejs/gobble-cli",


### PR DESCRIPTION
Fixes https://github.com/gobblejs/gobble/issues/110

The root cause was my text editor (kate): when making modifications to a file, it moves (renames) the existing file (`gobblefile.js`) into a backup file (`gobblefile.js~`), and re-creates a file with the original name. Pathwatcher interprets that as deleting the file.