### PR TITLE
Added ability to specify the name of the gobblefile.

### DIFF
--- a/lib/help.md
+++ b/lib/help.md
@@ -5,9 +5,9 @@
   Usage:
     gobble -h | --help
     gobble -v | --version
-    gobble [serve] [-p|--port <port>] [-e|--env <env>]
-    gobble build [-f|--force] [-e|--env <env>] <dest>
-    gobble watch [-f|--force] [-e|--env <env>] <dest>
+    gobble [serve] [-p|--port <port>] [-e|--env <env>] [--file <file>]
+    gobble build [-f|--force] [-e|--env <env>] [--file <file>] <dest>
+    gobble watch [-f|--force] [-e|--env <env>] [--file <file>] <dest>
 
   Options:
     -h --help      Show this message
@@ -15,6 +15,7 @@
     -p --port      Development server port [default: 4567]
     -f --force     Remove existing contents of <dest>
     -e --env       Environment setting [default: development]
+       --file      Gobblefile name [default: gobblefile]
     <dest>         Destination directory for `gobble build`
 
   For more information visit https://github.com/gobblejs/gobble/wiki

--- a/lib/help.md
+++ b/lib/help.md
@@ -5,9 +5,9 @@
   Usage:
     gobble -h | --help
     gobble -v | --version
-    gobble [serve] [-p|--port <port>] [-e|--env <env>] [--file <file>]
-    gobble build [-f|--force] [-e|--env <env>] [--file <file>] <dest>
-    gobble watch [-f|--force] [-e|--env <env>] [--file <file>] <dest>
+    gobble [serve] [-p|--port <port>] [-e|--env <env>] [-c|--config <config>]
+    gobble build [-f|--force] [-e|--env <env>] [-c|--config <config>] <dest>
+    gobble watch [-f|--force] [-e|--env <env>] [-c|--config <config>] <dest>
 
   Options:
     -h --help      Show this message
@@ -15,7 +15,7 @@
     -p --port      Development server port [default: 4567]
     -f --force     Remove existing contents of <dest>
     -e --env       Environment setting [default: development]
-       --file      Gobblefile name [default: gobblefile]
+    -c --config    Gobblefile name [default: gobblefile]
     <dest>         Destination directory for `gobble build`
 
   For more information visit https://github.com/gobblejs/gobble/wiki

--- a/lib/index.js
+++ b/lib/index.js
@@ -53,7 +53,7 @@ else {
 		name: 'gobble',
 		extensions: interpret.jsVariants,
 		v8flags: v8flags,
-		configName: command.file
+		configName: command.config
 	});
 
 	cli.on( 'require', function (name) {

--- a/lib/index.js
+++ b/lib/index.js
@@ -52,7 +52,8 @@ else {
 	cli = new Liftoff({
 		name: 'gobble',
 		extensions: interpret.jsVariants,
-		v8flags: v8flags
+		v8flags: v8flags,
+		configName: command.file
 	});
 
 	cli.on( 'require', function (name) {


### PR DESCRIPTION
This PR adds the `--file` option to the command line, which uses the [`configName`](https://github.com/js-cli/js-liftoff#optsconfigname) liftoff option.

This is useful when you have multiple gobblefiles which run different builds.
